### PR TITLE
fix bugs in im2rec.py

### DIFF
--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -144,6 +144,8 @@ def write_worker(q_out, fname, working_dir):
             print('time:', cur_time - pre_time, ' count:', count)
             pre_time = cur_time
         count += 1
+    fout.close()
+    os.remove(fname)
     os.rename(fname+'.tmp', fname)
 
 def parse_args():


### PR DESCRIPTION
**fout** should be closed before doing anything, if it is not **"WindowsError: [Error 32]"** will occur.
**fname** should be removed before renaming **fname+".tmp"** to **fname**, if it is not **"WindowsError: [Error 183]"** will occur.
But why here must rewrite the **lst** file?

PS, My OS is Windows 10.